### PR TITLE
Create PHP builder script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       uses: MilesChou/composer-action/8.0@master
       with:
         args: install --ignore-platform-req=ext-* --no-dev
-#    - name: "Move Cm_Cache_Backend_Redis /lib"
-#      run: "mkdir -p lib/Cm/Cache/Backend; cp vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/* lib/Cm/Cache/Backend/"
+    - name: "Clean vendor dir"
+      run: "composer run-script release-builder"
     - name: "Create ZIP file"
       run: zip -rq openmage-${{ github.event.release.tag_name }}-php${{ matrix.php-versions }}.zip . -x ".git/*"
     - name: "Attach ZIP to GitHub release"

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
   "autoload-dev": {
     "psr-4": { "OpenMage\\Tests\\Unit\\": "dev/tests/unit" }
   },
+  "autoload": {
+    "psr-4": { "OpenMage\\Scripts\\": "dev/scripts" }
+  },
   "extra": {
     "branch-alias": {
       "dev-main": "1.9.4.x-dev"
@@ -68,5 +71,10 @@
       "magento-hackathon/magento-composer-installer": true
     },
     "sort-packages": true
+  },
+  "scripts": {
+    "release-builder": [
+      "OpenMage\\Scripts\\Release::Run"
+    ]
   }
 }

--- a/dev/scripts/Release.php
+++ b/dev/scripts/Release.php
@@ -4,7 +4,6 @@ namespace OpenMage\Scripts;
 
 use Composer\Script\Event;
 use Composer\Semver\Constraint;
-use Composer\Package\Version\VersionParser;
 use Composer\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -77,7 +76,7 @@ class Release
             if ($type === 'magento-module') {
                 /** @var Composer\Package\Link $dependency */
                 foreach ($package->getRequires() as $name => $dependency) {
-                    $require[$name] ??= [];
+                    $require[$name] = $require[$name] ?? [];
                     $require[$name][] = $dependency->getConstraint();
                 }
                 $remove[] = $package->getName();

--- a/dev/scripts/Release.php
+++ b/dev/scripts/Release.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace OpenMage\Scripts;
+
+use Composer\Script\Event;
+use Composer\Semver\Constraint;
+use Composer\Package\Version\VersionParser;
+use Composer\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
+
+class Release
+{
+    /** @var Symfony\Component\Console\Output\ConsoleOutput $output */
+    static $output;
+
+    /** @var Composer\Composer $composer */
+    static $composer;
+
+    /** @var string $vendorPath */
+    static $vendorPath;
+
+    private static function _init(Event $event)
+    {
+        self::$output = new ConsoleOutput();
+        self::$composer = $event->getComposer();
+        self::$vendorPath = self::$composer->getConfig()->get('vendor-dir');
+    }
+
+    /**
+     * Run all commands
+     *
+     * @param Event $event
+     */
+    public static function run(Event $event)
+    {
+        self::updatePackages($event);
+        self::clean($event);
+    }
+
+    /**
+     * Remove packages not needed for the release ZIP while keeping sub-dependencies
+     *
+     * @param Event $event
+     */
+    public static function updatePackages(Event $event)
+    {
+        self::_init($event);
+
+        // Get all installed packages including dependencies
+        /** @var Composer\Package\CompletePackage[] $packages */
+        $packages = self::$composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
+
+        // List of packages for `composer require`
+        /** @var (Constraint\ConstraintInterface|string)[] $require */
+        $require = [
+            // We can manually add packages here
+            'symfony/polyfill-intl-idn' => ["^1.26"],
+        ];
+
+        // List of packages for `composer remove`
+        /** @var string[] $remove */
+        $remove = [
+            // We can manually remove packages here
+            // 'magento-hackathon/magento-composer-installer',
+        ];
+
+        /** @var Composer\Package\CompletePackage $package */
+        foreach ($packages as $package) {
+
+            /** @var string $type */
+            $type = $package->getType();
+
+            // Remove Magento module from composer.json, but we need to separately install its dependencies
+            if ($type === 'magento-module') {
+                /** @var Composer\Package\Link $dependency */
+                foreach ($package->getRequires() as $name => $dependency) {
+                    $require[$name] ??= [];
+                    $require[$name][] = $dependency->getConstraint();
+                }
+                $remove[] = $package->getName();
+            }
+
+            // Remove this repo when installed via aydin-hassan/magento-core-composer-installer
+            if ($type === 'magento-source') {
+                $remove[] = $package->getName();
+            }
+
+            // Remove any composer plugins, such as magento-hackathon/magento-composer-installer
+            if ($type === 'composer-plugin') {
+                $remove[] = $package->getName();
+            }
+        }
+
+        /** @var string[] $require */
+        $require = array_map(
+            function($name, $constraints) {
+                // Combine constraints from all packages that required this dependency
+                // This does not necessarily return a MultiConstraint instance if
+                // things can be reduced to a simple constraint
+                /** @var Composer\Semver\Constraint\ConstraintInterface $constraint */
+                $constraint = Constraint\MultiConstraint::create(array_unique($constraints));
+
+                // Return string that can be used for composer install, i.e.:
+                // "colinmollenhour/php-redis-session-abstract:>= 1.4.0.0-dev < 1.5.0.0-dev"
+                return $name . ':' . trim($constraint, '[]');
+            },
+            array_keys($require), $require
+        );
+
+        // Bootstrap composer application instance
+        /** @var Composer\Console\Application $app */
+        $app = new Application();
+        $app->setAutoExit(false);
+
+        $app->run(
+            new ArrayInput([
+                'command' => 'remove',
+                '--no-plugins' => true,
+                '--update-no-dev' => true,
+                '--ignore-platform-req' => ['ext-*'],
+                'packages' => $remove,
+            ]),
+            self::$output
+        );
+
+        $app->run(
+            new ArrayInput([
+                'command' => 'require',
+                '--no-plugins' => true,
+                '--update-no-dev' => true,
+                '--ignore-platform-req' => ['ext-*'],
+                'packages' => array_values($require),
+            ]),
+            self::$output
+        );
+
+        // // Alternatively we could use exec
+        // exec('composer remove --no-plugins --update-no-dev --ignore-platform-req=ext-* ' . implode(' ', $remove));
+        // exec('composer require --no-plugins --update-no-dev --ignore-platform-req=ext-* ' . '"' . implode('" "', $require) . '"');
+
+    }
+
+    /**
+     * Remove files such as markdown and unneeded files
+     *
+     * @param Event $event
+     */
+    public static function clean(Event $event)
+    {
+        self::_init($event);
+
+        $filesystem = new Filesystem();
+
+        // Remove markdown files
+        {
+            $finder = Finder::create()
+                    ->in(self::$vendorPath)
+                    ->files()
+                    ->name('*.md')
+                    ->name('*.markdown');
+
+            $filesystem->remove($finder);
+        }
+
+        // Remove .git directories
+        {
+            $finder = Finder::create()
+                    ->in(self::$vendorPath)
+                    ->directories()
+                    ->ignoreDotFiles(false)
+                    ->ignoreVCS(false)
+                    ->name('.git');
+
+            $filesystem->remove($finder);
+        }
+    }
+}


### PR DESCRIPTION
Hi @fballiano some suggestions on making the release builder better :)

Instead of hardcoding commands in release.yml, I added a new script at `dev/scripts/Release.php` that is called via composer with access to the `$composer` object.

What it does:
- It loops through all composer packages and removes type `magento-module` and type `composer-plugin`. The latter removes `magento-hackathon/magento-composer-installer` because we don't need it. If we are removing a `magento-module`, we first take note of its dependencies.
- Then it loops through packages again to re-install the dependencies of a module so that those exist in the release.
- It removes md files.

What I think is good about this method is that it doesn't hardcode things, but also it updates the composer.json. So if a user did rm -rf vendor they could just re-install it with `composer install`.

Thoughts?