### PR TITLE
Moved dependabot to weekly again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
PHPStan releases a new release every few days, we do not need to keep approving dependabot upgrades all the time, if dependabot would run once per week it would be more than enough, so that we don not get flooded with phpstan updates and we can focus on other activities too :-)